### PR TITLE
Don't doublequote around multiple args or it'll treat it as one

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -398,7 +398,7 @@ function backup_binaries() {
     BACKUPFILES="algod kmd carpenter doberman goal update.sh updater diagcfg"
     # add node_exporter to the files list we're going to backup, but only we if had it previously deployed.
     [ -f "${BINDIR}/node_exporter" ] && BACKUPFILES="${BACKUPFILES} node_exporter"
-    tar -zcf "${BINDIR}/backup/bin-v${CURRENTVER}.tar.gz" -C "${BINDIR}" "${BACKUPFILES}" >/dev/null 2>&1
+    tar -zcf "${BINDIR}/backup/bin-v${CURRENTVER}.tar.gz" -C "${BINDIR}" ${BACKUPFILES} >/dev/null 2>&1
 }
 
 function backup_data() {
@@ -408,7 +408,7 @@ function backup_data() {
     echo "Backing up current data files from ${CURDATADIR}..."
     mkdir -p "${BACKUPDIR}"
     BACKUPFILES="genesis.json wallet-genesis.id"
-    tar --no-recursion --exclude='*.log' --exclude='*.log.archive' --exclude='*.tar.gz' -zcf "${BACKUPDIR}/data-v${CURRENTVER}.tar.gz" -C "${CURDATADIR}" "${BACKUPFILES}" >/dev/null 2>&1
+    tar --no-recursion --exclude='*.log' --exclude='*.log.archive' --exclude='*.tar.gz' -zcf "${BACKUPDIR}/data-v${CURRENTVER}.tar.gz" -C "${CURDATADIR}" ${BACKUPFILES} >/dev/null 2>&1
 }
 
 function backup_current_version() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Shellcheck is great, except when it wants you to add double quotes around interpolated elements you want to be treated as separate arguments. The backup files functions in this script were treating them as one argument, and not finding the single file (instead of treating the elements as separate files).

## Test Plan

Run an upgrade with update.sh, and verify that backup files contain files:

`tar --list -zf backup/<tarball>`
`tar --list -zf PATH_TO_DATA_DIR/backup/<tarball>`
