### PR TITLE
Remove double quotes from around data dirs

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -413,7 +413,7 @@ function backup_data() {
 
 function backup_current_version() {
     backup_binaries
-    for DD in "${DATADIRS[@]}"; do
+    for DD in ${DATADIRS[@]}; do
         backup_data "${DD}"
     done
 }
@@ -592,7 +592,7 @@ function apply_fixups() {
     # Delete obsolete algorand binary - renamed to 'goal'
     rm "${BINDIR}/algorand" >/dev/null 2>&1
 
-    for DD in "${DATADIRS[@]}"; do
+    for DD in ${DATADIRS[@]}; do
         clean_legacy_logs "${DD}"
 
         # Purge obsolete cadaver files (now agreement.cdv[.archive])
@@ -673,7 +673,7 @@ if ! $DRYRUN; then
         fail_and_exit "Error installing new files"
     fi
 
-    for DD in "${DATADIRS[@]}"; do
+    for DD in ${DATADIRS[@]}; do
         if ! install_new_data "${DD}"; then
             fail_and_exit "Error installing data files into ${DD}"
         fi
@@ -681,7 +681,7 @@ if ! $DRYRUN; then
 
     copy_genesis_files
 
-    for DD in "${DATADIRS[@]}"; do
+    for DD in ${DATADIRS[@]}; do
         if ! check_for_new_ledger "${DD}"; then
             fail_and_exit "Error updating ledger in ${DD}"
         fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Double quotes around `${DATADIRS[@]}` can potentially prevent expansion in loops like `for DD in "${DATADIRS[@]}"`. For example, compare the output of the following:

`for x in one two three; do echo $x; done`

`for x in "one two three"; do echo $x; done`

This is slightly more controversial, however, as I have not seen this actually break in run time.

## Test Plan

Verify that the update.sh script appears to function as normal.
